### PR TITLE
Clean up "rs_strbld.rs" file

### DIFF
--- a/src/rs_strbld.rs
+++ b/src/rs_strbld.rs
@@ -1,16 +1,16 @@
 //rustc -C opt-level=3  rs_strbld.rs -o ..\exe\rs_strbld.exe
-use std::fs;
-use std::time::Instant;
 use std::env;
-use std::io::{self, Write};
 use std::fmt::Write as _;
+use std::fs;
+use std::io::{self, Write};
+use std::time::Instant;
 
 fn format_time(time_ms: u128) -> String {
-  let milliseconds = time_ms % 1000;
-  let seconds = (time_ms / 1000) % 60;
-  let minutes = (time_ms / 1000) / 60;
-  
-  format!("{:02}:{:02}:{02}", minutes, seconds, milliseconds)
+    let milliseconds = time_ms % 1000;
+    let seconds = (time_ms / 1000) % 60;
+    let minutes = (time_ms / 1000) / 60;
+
+    format!("{minutes:02}:{seconds:02}:{milliseconds:02}")
 }
 
 pub fn test(num: i64) {
@@ -18,40 +18,37 @@ pub fn test(num: i64) {
     io::stdout().flush().unwrap();
 
     let mut s = String::from("");
-    let now = Instant::now(); 
-    let mut i: i64 = 0; 
-     
+    let now = Instant::now();
+    let mut i: i64 = 0;
+
     for _ in 1..=num {
         i += 1;
-        //s.push_str(&format!(" R {}", i)); 
-        s.push_str(" R "); 
-        write!(s, "{}", i).unwrap();
+        // write!(s, " R {i}").unwrap();
+        s.push_str(" R ");
+        write!(s, "{i}").unwrap();
+    }
 
-     }
-
-    let elapsed = now.elapsed(); 
+    let elapsed = now.elapsed();
     let len = s.len();
 
     let s_time = format_time(elapsed.as_millis());
-    println!("  {} iter {} len {}", s_time, i, len);
+    println!("  {s_time} iter {i} len {len}");
 
     let file_path = "out/rust_output.txt";
     match fs::write(file_path, s) {
         Ok(_) => (),
-        Err(e) => eprintln!("Error saving string to file: {}", e),
-    } 
+        Err(e) => eprintln!("Error saving string to file: {e}"),
+    }
 }
 
-  fn main () {
- 
+fn main() {
     let args: Vec<String> = env::args().collect();
     if args.len() != 2 {
-        eprintln!("Usage: {} <num>", args[0]);
+        eprintln!("Usage: {path} <num>", path = args[0]);
         std::process::exit(1);
     }
 
     let num: i64 = args[1].parse().expect("Invalid input for num");
 
-    test(num);    
-
-  }  
+    test(num);
+}


### PR DESCRIPTION
This basically applies a couple of cosmetic cleanups:

- Fixed formatting (via `rustfmt`)
- Inlined formatting arguments (i.e. `"{} {}", x, y` => `"{x} {y}"`)

---

I also tried another alternative: `write!(s, " R {i}").unwrap();`, but unfortunately it's still slightly slower.

To give some additional context as to why `s.push_str(&format!(" R {}", i));` is so slow: `format!(…)` produces a dynamically allocated String on the heap (as opposed to say `write!(s, " R {i}")`, which takes a statically allocated `&'static str` and should not allocate any `String`s internally).